### PR TITLE
Typo fix

### DIFF
--- a/net/lion123dev/GameAnalytics.hx
+++ b/net/lion123dev/GameAnalytics.hx
@@ -202,7 +202,7 @@ class GameAnalytics
 			trace("No current session availbale");
 			return;
 		}
-		SendSessionEndEvent(Math.ceil((_sessionStartTime-Date.now().getTime()) / 1000));
+		SendSessionEndEvent(Math.ceil((Date.now().getTime() - _sessionStartTime) / 1000));
 		_sessionPresent = false;
 	}
 	


### PR DESCRIPTION
Typo leads to negative session length and 400 error on EndSession event
