### PR TITLE
Corrected Custom Design event format

### DIFF
--- a/net/lion123dev/GameAnalytics.hx
+++ b/net/lion123dev/GameAnalytics.hx
@@ -367,7 +367,7 @@ class GameAnalytics
 		var event_id:String = part1;
 		for (s in [part2, part3, part4, part5])
 		{
-			if (s != null) event_id += s;
+			if (s != null) event_id += (":" + s);
 		}
 		var event:DesignEvent = Events.GetDesignEvent(_defaultValues, event_id);
 		if (value != null) event.value = value;


### PR DESCRIPTION
Corrected format accordingly to http://www.gameanalytics.com/docs/custom-events ([category]:[sub_category]:[outcome])
